### PR TITLE
[Fix] #44 - 학교 커뮤니티 페이지에서 더보기로 url을 이동

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -2,13 +2,17 @@
 
 import styled from "styled-components";
 import {BoardPost} from './BoardPost';
-export const Board = ({title, posts}) => {
+import { Link } from "react-router-dom";
+
+export const Board = ({title, posts, link}) => {
 
     return (
         <Wrapper>
             <Top>
                 <Title>{title}</Title>
-                <More>더보기</More>
+                <Link to={link}>
+                    <More>더보기</More>
+                </Link>
             </Top>
             <Posts>
                 {posts.map((post, index) => (
@@ -27,7 +31,6 @@ const Wrapper = styled.div`
     padding: 15px 20px;
     display: flex;
     flex-direction: column;
-
 `;
 
 const Top = styled.div`

--- a/src/pages/commuPage/CommuMainPage.jsx
+++ b/src/pages/commuPage/CommuMainPage.jsx
@@ -11,7 +11,7 @@ export const CommuMainPage = () => {
             <S.Content>
                 <S.Title>게시판</S.Title>
                 <S.Posts>
-                <S.Post>
+                    <S.Post>
                         <S.Top>
                             <S.Name>💬 자유 게시판</S.Name>
                             <Link to='/defaultBoard'>

--- a/src/pages/schMainPage/SchMainPage.jsx
+++ b/src/pages/schMainPage/SchMainPage.jsx
@@ -42,8 +42,8 @@ export const SchMainPage = () => {
           </S.Button>
         </S.Buttons>
         <S.Boards>
-          <Link to='/schAllBoard'><Board title="전체게시판" posts={posts1}/></Link>
-          <Link to='/schQnaBoard'><Board title="질문게시판" posts={posts2} /></Link>
+          <Board title="전체게시판" posts={posts1} link='/schAllBoard' />
+          <Board title="질문게시판" posts={posts2} link='/schQnaBoard' />
         </S.Boards>
         <Footer/>
     </S.Wrapper>


### PR DESCRIPTION
## 🔍 What is the PR?

학교 커뮤니티 URL 임의로 걸어둔거 삭제하고 더보기에 연결했습니다

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/4537c58f-4c38-49e6-b196-280260d01946)
링크도 props로 함께 전달받도록 했습니다


## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- ex) #44 
